### PR TITLE
fix: mobile status bar theme-color and viewport layout

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -54,12 +54,15 @@ const menus = [
     const current = localStorage.getItem('theme');
     // Safari: transition 활성 중 속성 변경 시 repaint 누락 방지
     document.body.classList.add('notransition');
+    const themeColorMeta = document.getElementById('theme-color-meta');
     if (current === 'dark' || (!current)) {
       localStorage.setItem('theme', 'light');
       document.body.removeAttribute('data-theme');
+      themeColorMeta?.setAttribute('content', '#faf9f6');
     } else {
       localStorage.setItem('theme', 'dark');
       document.body.setAttribute('data-theme', 'dark');
+      themeColorMeta?.setAttribute('content', '#131418');
     }
     void document.body.offsetHeight;
     requestAnimationFrame(() => {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -46,7 +46,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
   <link rel="manifest" href="/favicons/site.webmanifest" />
-  <meta name="theme-color" content="#2c2c2c" />
+  <meta name="theme-color" content="#131418" id="theme-color-meta" />
 
   <!-- Fonts -->
   <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
@@ -61,8 +61,12 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   {showStars && <StarBackground />}
   <script is:inline>
     const theme = localStorage.getItem('theme');
+    var themeColorMeta = document.getElementById('theme-color-meta');
     if (theme === 'dark' || (!theme)) {
       document.body.setAttribute('data-theme', 'dark');
+      themeColorMeta.setAttribute('content', '#131418');
+    } else {
+      themeColorMeta.setAttribute('content', '#faf9f6');
     }
   </script>
   <Navbar currentPath={Astro.url.pathname} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -46,15 +46,21 @@ const recentPosts = posts.slice(0, 5);
       overflow: hidden;
       display: flex;
       flex-direction: column;
-      height: 100vh;
       height: 100dvh;
-      padding-top: env(safe-area-inset-top, 0px);
+      height: 100vh;
+      min-height: 0;
+    }
+    @supports (height: 100dvh) {
+      :global(body) {
+        height: 100dvh;
+      }
     }
     :global(.wrapper) {
       display: flex;
       flex-direction: column;
       flex: 1;
       min-height: 0;
+      overflow: hidden;
     }
     :global(.page-content) {
       flex: 1;
@@ -62,13 +68,18 @@ const recentPosts = posts.slice(0, 5);
       flex-direction: column;
       justify-content: center;
       margin-bottom: 0;
+      min-height: 0;
     }
     .author {
       margin-top: 0;
-      margin-bottom: 2rem;
+      margin-bottom: 1.5rem;
     }
     :global(.footer) {
       margin-top: auto;
+      flex-shrink: 0;
+    }
+    :global(.navbar) {
+      flex-shrink: 0;
     }
   </style>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- theme-color를 페이지 배경색에 맞춰 동적 변경 (다크: #131418, 라이트: #faf9f6)
- 홈 페이지 body를 flex + 100dvh로 설정하여 스크롤 없이 뷰포트 안에 모든 요소 배치