### PR TITLE
fix: prevent profile from being covered by mobile status bar

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,11 +20,11 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <html lang="ko-KR">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content={description} />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <link rel="canonical" href={canonicalURL} />
 
   <!-- Open Graph -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -46,14 +46,9 @@ const recentPosts = posts.slice(0, 5);
       overflow: hidden;
       display: flex;
       flex-direction: column;
-      height: 100dvh;
       height: 100vh;
+      height: 100svh;
       min-height: 0;
-    }
-    @supports (height: 100dvh) {
-      :global(body) {
-        height: 100dvh;
-      }
     }
     :global(.wrapper) {
       display: flex;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -853,7 +853,6 @@ mark,
   margin-left: auto;
   border-bottom: none;
   padding: 15px 30px;
-  padding-top: calc(15px + env(safe-area-inset-top, 0px));
 }
 
 .background {


### PR DESCRIPTION
## Summary
- viewport-fit=cover 제거 → 콘텐츠가 상태바 아래로 들어가지 않음
- theme-color로 상태바 색상을 페이지 배경에 맞춤 (투명 효과)
- 100svh 사용으로 iOS Safari URL바 고려한 정확한 높이 계산