### PR TITLE
fix: transparent status bar with body safe-area padding

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,11 +20,11 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <html lang="ko-KR">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="description" content={description} />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="canonical" href={canonicalURL} />
 
   <!-- Open Graph -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,6 +49,7 @@ const recentPosts = posts.slice(0, 5);
       height: 100vh;
       height: 100svh;
       min-height: 0;
+      box-sizing: border-box;
     }
     :global(.wrapper) {
       display: flex;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -552,6 +552,7 @@ body {
   font-feature-settings: "kern" 1;
   font-kerning: normal;
   box-sizing: border-box;
+  padding-top: env(safe-area-inset-top, 0px);
 }
 
 h1,


### PR DESCRIPTION
## Summary
- viewport-fit=cover + black-translucent로 상태바 투명 처리
- body에 padding-top: env(safe-area-inset-top) 추가하여 콘텐츠가 상태바 아래로 가려지지 않도록 처리
- 별 배경은 상태바 뒤로 비쳐 보임