### PR TITLE
fix: prevent profile clipping on mobile home page

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,11 +20,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <html lang="ko-KR">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content={description} />
-  <meta name="mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="canonical" href={canonicalURL} />
 
   <!-- Open Graph -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,22 +56,27 @@ const recentPosts = posts.slice(0, 5);
       flex-direction: column;
       flex: 1;
       min-height: 0;
-      overflow: hidden;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+    }
+    :global(.wrapper)::-webkit-scrollbar {
+      display: none;
     }
     :global(.page-content) {
       flex: 1;
       display: flex;
       flex-direction: column;
-      justify-content: center;
       margin-bottom: 0;
-      min-height: 0;
     }
     .author {
-      margin-top: 0;
+      margin-top: auto;
       margin-bottom: 1.5rem;
     }
+    :global(.posts-item-note) {
+      margin-bottom: auto;
+    }
     :global(.footer) {
-      margin-top: auto;
       flex-shrink: 0;
     }
     :global(.navbar) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -552,7 +552,6 @@ body {
   font-feature-settings: "kern" 1;
   font-kerning: normal;
   box-sizing: border-box;
-  padding-top: env(safe-area-inset-top, 0px);
 }
 
 h1,


### PR DESCRIPTION
## Summary
- viewport-fit=cover 제거 (일반 Safari/Chrome에서 불필요, 오히려 콘텐츠를 상태바 아래로 밀어넣음)
- justify-content: center → margin-top: auto로 변경하여 프로필 상단 잘림 방지
- wrapper overflow를 숨김 스크롤로 변경 (작은 화면에서도 콘텐츠 잘리지 않음)